### PR TITLE
allow message prop type to be either string or object (for passing dom)

### DIFF
--- a/src/react-aria-tooltip.jsx
+++ b/src/react-aria-tooltip.jsx
@@ -122,7 +122,10 @@ ReactARIAToolTip.defaultProps = {
 }
 
 ReactARIAToolTip.propTypes = {
-    message: PropTypes.string.isRequired,
+    message: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ]).isRequired,
     direction: PropTypes.string,
     duration: PropTypes.oneOfType([
         PropTypes.string,

--- a/src/tooltip-content.jsx
+++ b/src/tooltip-content.jsx
@@ -17,7 +17,10 @@ const ToolTipContent = ({ className, direction, message, active, bgcolor }) => {
 ToolTipContent.displayName = 'ToolTipContent'
 
 ToolTipContent.propTypes = {
-    message: PropTypes.string.isRequired,
+    message: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ]).isRequired,
     direction: PropTypes.string.isRequired,
     active: PropTypes.bool.isRequired,
     bgcolor: PropTypes.string

--- a/src/tooltip-message.jsx
+++ b/src/tooltip-message.jsx
@@ -13,7 +13,10 @@ const TooltipMessage = ({ className, message, arrowSize }) => {
 TooltipMessage.displayName = 'TooltipMessage'
 
 TooltipMessage.propTypes = {
-    message: PropTypes.string.isRequired
+    message: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ]).isRequired
 }
 
 export default styled(TooltipMessage)`


### PR DESCRIPTION
This PR allows DOM nodes / jsx to be passed for the message prop. Useful if you need some style in your tooltip.

This is a minimal solution to get rid of the warning. I think a useful enhancement would be to check for non-string messages and render them without any wrapping `<p>` element.