### PR TITLE
Bump styled-components to ^2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/egoens/react-aria-tooltip#readme",
   "dependencies": {
     "prop-types": "15.6.0",
-    "styled-components": "^1.0.10"
+    "styled-components": "^2.4.0"
   },
   "peerDependencies": {
     "react": "^16.0"
@@ -42,7 +42,6 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "styled-components": "^1.0.10",
     "webpack": "^1.13.0"
   }
 }


### PR DESCRIPTION
Given that `styled-components` currently gets bundled with `react-aria-tooltip`, there are big performance gains to be made by moving to `styled-components` 2.4.0. `webpack-bundle-analyzer` calculates a drop from 245.09kb to 64.53kb. In a later PR, hoping to move `styled-components` to `peerDependencies` as we are currently bundling it twice in our application.