### PR TITLE
Move styled-components to peerDependencies and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "homepage": "https://github.com/egoens/react-aria-tooltip#readme",
   "dependencies": {
-    "prop-types": "15.6.0",
-    "styled-components": "^2.4.0"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0"
+    "react": "^16.0",
+    "styled-components": "^2.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/egoens/react-aria-tooltip#readme",
   "dependencies": {
     "prop-types": "15.6.0",
-    "styled-components": "^1.0.10"
+    "styled-components": "^2.4.0"
   },
   "peerDependencies": {
     "react": "^16.0"
@@ -42,7 +42,6 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "styled-components": "^1.0.10",
     "webpack": "^1.13.0"
   }
 }


### PR DESCRIPTION
Given that `styled-components` currently gets bundled with `react-aria-tooltip`, there are big performance gains to be made by moving to `styled-components` 2. `webpack-bundle-analyzer` calculates for us that `react-aria-tooltip` drops from 262.28kb to 17.18kb. Also, by moving `styled-components` to `peerDependencies` we can prevent it being bundled more than once in an application.