### PR TITLE
Changes default font color at the content wrapper level

### DIFF
--- a/src/tooltip-content.jsx
+++ b/src/tooltip-content.jsx
@@ -1,102 +1,101 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import TooltipMessage from './tooltip-message'
-import styled from 'styled-components'
+import React from "react";
+import PropTypes from "prop-types";
+import TooltipMessage from "./tooltip-message";
+import styled from "styled-components";
 
-const arrowSize = 5
+const arrowSize = 5;
 
 const ToolTipContent = ({ className, direction, message, active, bgcolor }) => {
-    const tooltipClasses = `${direction} ra-tooltip ${className}`
+  const tooltipClasses = `${direction} ra-tooltip ${className}`;
 
-    return (
-        <div className={tooltipClasses} aria-hidden={active ? false : true}>
-            <TooltipMessage message={message} arrowSize={arrowSize} />
-        </div>
-    )
-}
-ToolTipContent.displayName = 'ToolTipContent'
+  return (
+    <div className={tooltipClasses} aria-hidden={active ? false : true}>
+      <TooltipMessage message={message} arrowSize={arrowSize} />
+    </div>
+  );
+};
+ToolTipContent.displayName = "ToolTipContent";
 
 ToolTipContent.propTypes = {
-    message: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.object,
-        PropTypes.element
-    ]).isRequired,
-    direction: PropTypes.string.isRequired,
-    active: PropTypes.bool.isRequired,
-    bgcolor: PropTypes.string
-}
+  message: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.element
+  ]).isRequired,
+  direction: PropTypes.string.isRequired,
+  active: PropTypes.bool.isRequired,
+  bgcolor: PropTypes.string
+};
 
 export default styled(ToolTipContent)`
-    position: absolute;
-    background: ${props => props.bgcolor};
-    transition: all .25s;
-    display: none;
+  position: absolute;
+  background: ${props => props.bgcolor};
+  transition: all 0.25s;
+  display: none;
+  color: white;
 
-    p {
-        padding: .5rem 1rem;
-        margin: 0;
-        white-space: nowrap;
-        color: white;
-    }
+  * {
+    margin: 0;
+    white-space: nowrap;
+  }
 
-    &.top {
-        top: 0;
+  &.top {
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -120%);
+
+    .ra-tooltip-message {
+      &:after {
+        top: 100%;
         left: 50%;
-        transform: translate(-50%,-120%);
-
-        .ra-tooltip-message {
-            &:after {
-                top: 100%;
-                left: 50%;
-                border-top-color: ${props => props.bgcolor};
-            }
-        }
+        border-top-color: ${props => props.bgcolor};
+      }
     }
+  }
 
-    &.bottom {
-        bottom: 0;
+  &.bottom {
+    bottom: 0;
+    left: 50%;
+    transform: translate(-50%, 120%);
+
+    .ra-tooltip-message {
+      &:after {
+        top: -${arrowSize * 2}px;
         left: 50%;
-        transform: translate(-50%,120%);
-
-        .ra-tooltip-message {
-            &:after {
-                top: -${arrowSize * 2}px;
-                left: 50%;
-                border-bottom-color: ${props => props.bgcolor};
-            }
-        }
+        border-bottom-color: ${props => props.bgcolor};
+      }
     }
+  }
 
-    &.left {
+  &.left {
+    top: 50%;
+    left: -${arrowSize}px;
+    transform: translate(-100%, -50%);
+
+    .ra-tooltip-message {
+      &:after {
         top: 50%;
-        left: -${arrowSize}px;
-        transform: translate(-100%,-50%);
-
-        .ra-tooltip-message {
-            &:after {
-                top: 50%;
-                left: 100%;
-                margin-left: 0;
-                margin-top: -${arrowSize}px;
-                border-left-color: ${props => props.bgcolor};
-            }
-        }
+        left: 100%;
+        margin-left: 0;
+        margin-top: -${arrowSize}px;
+        border-left-color: ${props => props.bgcolor};
+      }
     }
+  }
 
-    &.right {
+  &.right {
+    top: 50%;
+    right: -${arrowSize}px;
+    transform: translate(100%, -50%);
+
+    .ra-tooltip-message {
+      &:after {
         top: 50%;
-        right: -${arrowSize}px;
-        transform: translate(100%,-50%);
-
-        .ra-tooltip-message  {
-            &:after {
-                top: 50%;
-                right: 100%;
-                margin-left: 0;
-                margin-top: -${arrowSize}px;
-                border-right-color: ${props => props.bgcolor};
-            }
-        }
+        right: 100%;
+        margin-left: 0;
+        margin-top: -${arrowSize}px;
+        border-right-color: ${props => props.bgcolor};
+      }
     }
-`
+  }
+`;

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1,33 +1,37 @@
-import React from "react"
+import React from "react";
 
-import { storiesOf } from "@storybook/react"
-import { action } from "@storybook/addon-actions"
-import { linkTo } from "@storybook/addon-links"
-import centered from "@storybook/addon-centered"
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { linkTo } from "@storybook/addon-links";
+import centered from "@storybook/addon-centered";
 
-import ReactARIAToolTip from "../src/react-aria-tooltip"
+import ReactARIAToolTip from "../src/react-aria-tooltip";
 
 // defind tooltip options
-const directions = ["top", "right", "bottom", "left"]
-const eventTypes = ["click", "hover"]
+const directions = ["top", "right", "bottom", "left"];
+const eventTypes = ["click", "hover"];
 
 // setup the stories
 let stories = eventTypes.map(type => {
-    return storiesOf(type, module)
-})
+  return storiesOf(type, module);
+});
 
 // map types and diretions to stories
 stories.map(story => {
-    directions.map(direction => {
-        story.addDecorator(centered)
-        story.add(direction, () => (
-            <ReactARIAToolTip
-                message="Your custom message"
-                direction={direction}
-                eventType={story.kind}
-            >
-                {story.kind === "click" ? <div>click on me</div> : <div>hover over me</div>}
-            </ReactARIAToolTip>
-        ))
-    })
-})
+  directions.map(direction => {
+    story.addDecorator(centered);
+    story.add(direction, () => (
+      <ReactARIAToolTip
+        message="Your custom message"
+        direction={direction}
+        eventType={story.kind}
+      >
+        {story.kind === "click" ? (
+          <div>click on me</div>
+        ) : (
+          <div>hover over me</div>
+        )}
+      </ReactARIAToolTip>
+    ));
+  });
+});


### PR DESCRIPTION
In order allow for non-string content to show in the tooltip, the font color definition needed to move up to the content wrapper level. This accommodates for any html option to inherit the default color, instead of only the `<p>` tag.