### PR TITLE
add allowClickOnSelf prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ return (
 
 1.  `message` string that will display in the tooltip (required)
 1.  `eventType` this can either be 'click' or 'hover' (default 'click')
+1.  `allowClickOnSelf` this is only applicable to the click `eventType`. This value defines whether a click on the target element will also toggle the tooltip (default 'false')
 1.  `direction` the placement of the tooltip. Can be one of four options 'top', 'bottom', 'right', 'left' (default 'top')
 1.  `duration` this is only applicable to the click `eventType`. This value defines the amount of time the tooltip is present after the user clicks the target element (default 2000). If the value is `0` or `false` then the tooltip will persist until the user clicks outside of the bounds of any of the tooltip content and/or button.
 1.  `bgcolor` controls the background color of the tooltip. (default '#000')

--- a/dist/react-aria-tooltip.js
+++ b/dist/react-aria-tooltip.js
@@ -46,7 +46,7 @@ var ReactARIAToolTip = function (_React$Component) {
 
     _this.handleWindowClick = function (e) {
       if (_this.state.active) {
-        if (_this.node.contains(e.target)) {
+        if (!_this.props.allowClickOnSelf && _this.node.contains(e.target)) {
           return;
         }
         _this.setState({ active: false });
@@ -201,6 +201,7 @@ ReactARIAToolTip.defaultProps = {
   direction: "top",
   duration: 2000,
   eventType: "click",
+  allowClickOnSelf: false,
   bgcolor: "#000"
 };
 
@@ -210,6 +211,7 @@ ReactARIAToolTip.propTypes = {
   duration: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number, _propTypes2.default.bool]),
   children: _propTypes2.default.node,
   eventType: _propTypes2.default.oneOf(["hover", "click", "outside"]),
+  allowClickOnSelf: _propTypes2.default.bool,
   id: _propTypes2.default.string,
   bgcolor: _propTypes2.default.string
 };

--- a/dist/react-aria-tooltip.js
+++ b/dist/react-aria-tooltip.js
@@ -46,7 +46,7 @@ var ReactARIAToolTip = function (_React$Component) {
 
     _this.handleWindowClick = function (e) {
       if (_this.state.active) {
-        if (!_this.props.allowClickOnSelf && _this.node.contains(e.target)) {
+        if (_this.node.contains(e.target)) {
           return;
         }
         _this.setState({ active: false });
@@ -92,10 +92,14 @@ var ReactARIAToolTip = function (_React$Component) {
   }, {
     key: "handleClick",
     value: function handleClick() {
-      this.setState({ active: true });
-      if (this.state.duration) {
-        clearTimeout(this.timer);
-        this.startTimer();
+      if (this.props.allowClickOnSelf) {
+        this.setState({ active: !this.state.active });
+      } else {
+        this.setState({ active: true });
+        if (this.state.duration) {
+          clearTimeout(this.timer);
+          this.startTimer();
+        }
       }
     }
   }, {

--- a/src/react-aria-tooltip.jsx
+++ b/src/react-aria-tooltip.jsx
@@ -38,7 +38,7 @@ class ReactARIAToolTip extends React.Component {
 
   handleWindowClick = e => {
     if (this.state.active) {
-      if (this.node.contains(e.target)) {
+      if (!this.props.allowClickOnSelf && this.node.contains(e.target)) {
         return;
       }
       this.setState({ active: false });
@@ -133,6 +133,7 @@ ReactARIAToolTip.defaultProps = {
   direction: "top",
   duration: 2000,
   eventType: "click",
+  allowClickOnSelf: false,
   bgcolor: "#000"
 };
 
@@ -150,6 +151,7 @@ ReactARIAToolTip.propTypes = {
   ]),
   children: PropTypes.node,
   eventType: PropTypes.oneOf(["hover", "click", "outside"]),
+  allowClickOnSelf: PropTypes.bool,
   id: PropTypes.string,
   bgcolor: PropTypes.string
 };

--- a/src/react-aria-tooltip.jsx
+++ b/src/react-aria-tooltip.jsx
@@ -38,7 +38,7 @@ class ReactARIAToolTip extends React.Component {
 
   handleWindowClick = e => {
     if (this.state.active) {
-      if (!this.props.allowClickOnSelf && this.node.contains(e.target)) {
+      if (this.node.contains(e.target)) {
         return;
       }
       this.setState({ active: false });
@@ -46,10 +46,14 @@ class ReactARIAToolTip extends React.Component {
   };
 
   handleClick() {
-    this.setState({ active: true });
-    if (this.state.duration) {
-      clearTimeout(this.timer);
-      this.startTimer();
+    if (this.props.allowClickOnSelf) {
+      this.setState({ active: !this.state.active });
+    } else {
+      this.setState({ active: true });
+      if (this.state.duration) {
+        clearTimeout(this.timer);
+        this.startTimer();
+      }
     }
   }
 

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -49,4 +49,17 @@ storiesOf("outside", module)
         <div>click on me</div>
       </ReactARIAToolTip>
     );
+  })
+  .add("allowClickOnSelf", () => {
+    return (
+      <ReactARIAToolTip
+        message="Your custom message"
+        direction="bottom"
+        eventType="click"
+        allowClickOnSelf
+        duration={0}
+      >
+        <div>click on me</div>
+      </ReactARIAToolTip>
+    );
   });


### PR DESCRIPTION
Thought it would be better to just open a PR rather than write an issue, we are looking for the ability to close the tooltip when the user clicks on the tooltip trigger, right now this is disabled. I thought adding a prop was the best approach.

Would there be any chance of getting this merged?