### PR TITLE
replace yarn install with yarn add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This component leverages a style library called [Styled Components](https://styl
 To download or install react-aria-tooltip use your package manager of choice by running one of the following commands.
 
 ### Via yarn
-`yarn install react-aria-tooltip`
+`yarn add react-aria-tooltip`
 
 ### Via npm
 `npm install react-aria-tooltip`


### PR DESCRIPTION
The `install` has been replaced with `add` to add new dependencies